### PR TITLE
Remove extraneous curly brace in text

### DIFF
--- a/src/dont/dont-god-commit.adoc
+++ b/src/dont/dont-god-commit.adoc
@@ -4,6 +4,6 @@ God commits or big bang commits are not good because they are difficul to unders
 
 Also if a commit needs to be cherry picked in/out, then it makes it very difficult.
 
-For example if files are being reformatted, this should be done in 1 commit, not with other changes otherwise it is confusing.{
+For example if files are being reformatted, this should be done in 1 commit, not with other changes otherwise it is confusing.
 
 TIP: Each commit should do one single item


### PR DESCRIPTION
| Type | Bug Fix |
| :--- | :--- |
| Screenshot | no |
| Description of changes | Removing an extra curly brace "{" that doesn't belong in the text. |
