### PR TITLE
Issue 136 clone link in contributing page uses wrong url

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,4 +14,4 @@ agree to abide by the [Contributor Covenant](http://contributor-covenant.org).
 
 **DONE**
 
-Once the **Pull Request** has been accepted & merged into `master`, it will automatically be built (with [AsciiDoctor](http://asciidoctor.org) html & pdf) & [deployed](https://eddiejaoude.github.io/book-open-source-tips/)
+Once the **Pull Request** has been accepted & merged into `master`, it will automatically be built (with [AsciiDoctor](http://asciidoctor.org) html & pdf) & [deployed](https://eddiejaoude.github.io/book-open-source-tips/) 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,8 +5,8 @@ agree to abide by the [Contributor Covenant](http://contributor-covenant.org).
 
 ## Steps
 
-1. [Fork](https://help.github.com/articles/fork-a-repo/) this [project](https://github.com/eddiejaoude/book-open-source-tips) 
-2. [Clone](https://help.github.com/articles/fork-a-repo/#step-2-create-a-local-clone-of-your-fork) your forked version `git clone git@github.com:<YOUR-USERNAME>/book-open-source-tips.git`
+1. [Fork](https://help.github.com/articles/fork-a-repo/) this [project](https://github.com/eddiejaoude/book-open-source-tips)
+2. [Clone](https://docs.github.com/get-started/quickstart/fork-a-repo#cloning-your-forked-repository) your forked version `git clone git@github.com:<YOUR-USERNAME>/book-open-source-tips.git`
 3. Make changes (mostly probably in `src/` directory)
 4. [Commit](https://help.github.com/articles/adding-a-file-to-a-repository-using-the-command-line/) your changes (write a short descriptive message of what you have done)
 5. [Push](https://help.github.com/articles/pushing-to-a-remote/) yours changes to your forked version
@@ -14,4 +14,4 @@ agree to abide by the [Contributor Covenant](http://contributor-covenant.org).
 
 **DONE**
 
-Once the **Pull Request** has been accepted & merged into `master`, it will automatically be built (with [AsciiDoctor](http://asciidoctor.org) html & pdf) & [deployed](https://eddiejaoude.github.io/book-open-source-tips/) 
+Once the **Pull Request** has been accepted & merged into `master`, it will automatically be built (with [AsciiDoctor](http://asciidoctor.org) html & pdf) & [deployed](https://eddiejaoude.github.io/book-open-source-tips/)


### PR DESCRIPTION
| Type | Bug Fix  |
| :--- | :--- |
| Screenshot |  no |
| Description of changes | Fixes issue #136 where the Clone link in the CONTRIBUTING page didn't link to the right part of the page. |
